### PR TITLE
Add custom domains, popup option

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,11 @@
 'use strict';
 
 chrome.runtime.onInstalled.addListener(function() {
-  chrome.storage.sync.set({owaIntercept: "on"}, function() {
-    console.log('Intercept activated!');
-  });
+  chrome.storage.sync.get('owaIntercept', (data) => {
+    if (!data.owaIntercept) {
+      chrome.storage.sync.set({owaIntercept: "on"}, function() {
+        console.log('Intercept activated!');
+      });
+    }
+  })
 });

--- a/mailtowa.js
+++ b/mailtowa.js
@@ -4,15 +4,19 @@
 // https://outlook.{office|live}.com/owa/?path=/mail/action/compose&to={to}&subject={subject}&body={body}&cc={cc}&bcc={bcc}"
 
 const handleLink = (e) => {
-    theTarget = e.target;
+    const theTarget = e.target;
     if (theTarget.tagName.toLowerCase() == 'a' && theTarget.href.substr(0,7) === 'mailto:') {
-        chrome.storage.sync.get('owaIntercept', (data) => {
+        chrome.storage.sync.get(['owaIntercept', 'owaDomain', 'owaPopup'], (data) => {
             if (String(data.owaIntercept).startsWith("on")) {
                 const mailtoLink = theTarget.href.substr(7).replace('?', '&');
                 const paramString = `to=${mailtoLink}`;
-                const urlString = data.owaIntercept.length === 2 ? "office" : "live";
-                const outlookString = `https://outlook.${urlString}.com/owa/?path=/mail/action/compose&${paramString}`;
-                window.open(outlookString, '_blank');
+                const domain = {
+                    on: 'outlook.office.com',
+                    on_live: 'outlook.live.com',
+                    on_custom: data.owaDomain
+                }[data.owaIntercept];
+                const outlookString = `https://${domain}/owa/?path=/mail/action/compose&${paramString}`;
+                window.open(outlookString, '_blank', data.owaPopup ? 'width=800' : null);
             }
         });
         e.preventDefault();

--- a/popup.html
+++ b/popup.html
@@ -2,29 +2,61 @@
 <html>
   <head>
       <meta charset="UTF-8" />
+      <style>
+          section {
+              margin-bottom: 1.5em;
+          }
+          .input-control {
+              margin-bottom: 1em;
+          }
+          input[type=radio],
+          input[type=checkbox] {
+              margin: 0 10px;
+          }
+          input:checked + label {
+              font-weight: bold;
+          }
+          .domain {
+              padding-left: 50px;
+          }
+          input:not(:checked) ~ .domain {
+              display: none;
+          }
+      </style>
   </head>
 
   <body style="width: 500px;">
       <h1>MailtOWA</h1>
-      <h4>Mailto links go to:</h4>
-      <p>
-        <label>
-          <input type="radio" name="intercept" id="interceptOn" value="on" style="margin: 0 10px 0 10px;">
-          <span id="interceptOnText">Outlook.Office (company accounts)</span>
-        </label>
-      </p><p>
-        <label>
-          <input type="radio" name="intercept" id="interceptOnLive" value="off" style="margin: 0 10px 0 10px;">
-          <span id="interceptOnLiveText">Outlook.Live (private accounts)</span>
-        </label>
-      </p><p>
-        <label>
-          <input type="radio" name="intercept" id="interceptOff" value="off" style="margin: 0 10px 0 10px;">
-          <span id="interceptOffText">default application (turn off this extension)</span>
-        </label>
-      </p><p>
-          ... the missing bit of functionality that Microsoft should have provided?
-      </p>
+      <section>
+        <h4>Mailto links go to:</h4>
+        <div class="input-control">
+          <input type="radio" name="intercept" id="interceptOn" value="on">
+          <label for="interceptOn">Outlook.Office (company accounts)</label>
+        </div>
+        <div class="input-control">
+          <input type="radio" name="intercept" id="interceptOnLive" value="on_live">
+          <label for="interceptOnLive">Outlook.Live (private accounts)</label>
+        </div>
+        <div class="input-control">
+          <input type="radio" name="intercept" id="interceptOnCustom" value="on_custom">
+          <label for="interceptOnCustom">Custom domain (company accounts on an internal server)</label>
+          <div class="domain">
+            <label for="domain">Domain:</label>
+            <input type="text" name="domain" id="domain">
+          </div>
+        </div>
+        <div class="input-control">
+          <input type="radio" name="intercept" id="interceptOff" value="off">
+          <label for="interceptOff">default application (turn off this extension)</label>
+        </div>
+      </section>
+      <section>
+        <div class="input-control">
+          <input type="checkbox" name="popup" id="popup">
+          <label for="popup">Open in popup</label>
+        </div>
+      </section>
+      <p>... the missing bit of functionality that Microsoft should have provided?</p>
       <div style="text-align:center">
           <strong>A free extension by<br/> <a href="https://i❤️.ws" target="_blank">i❤️.ws</a> Emoji Domains</strong>
           <br/>

--- a/popup.js
+++ b/popup.js
@@ -1,70 +1,24 @@
 'use strict';
 
-const interceptOn = document.getElementById('interceptOn');
-const interceptOnLive = document.getElementById('interceptOnLive');
-const interceptOff = document.getElementById('interceptOff');
-const interceptOnText = document.getElementById('interceptOnText');
-const interceptOnLiveText = document.getElementById('interceptOnLiveText');
-const interceptOffText = document.getElementById('interceptOffText');
+const radios = Array.from(document.querySelectorAll('input[name=intercept]'));
+const domainInput = document.querySelector('input[name=domain]');
+const popupCheckbox = document.querySelector('input[name=popup]');
 
-chrome.storage.sync.get('owaIntercept', (data) => {
-    console.log('data', data);
-    if (data.owaIntercept === "on") {
-        interceptOn.checked = true;
-        interceptOnLive.checked = false;
-        interceptOff.checked = false;
-        interceptOnText.style.fontWeight = 'bold';
-        interceptOnLive.style.fontWeight = 'normal';
-        interceptOffText.style.fontWeight = 'normal';
-    } else if (data.owaIntercept === "on_live") {
-        interceptOn.checked = false;
-        interceptOnLive.checked = true;
-        interceptOff.checked = false;
-        interceptOnText.style.fontWeight = 'normal';
-        interceptOnLiveText.style.fontWeight = 'bold';
-        interceptOffText.style.fontWeight = 'normal';
-    } else {
-        interceptOn.checked = false;
-        interceptOnLive.checked = false;
-        interceptOff.checked = true;
-        interceptOnText.style.fontWeight = 'normal';
-        interceptOnLiveText.style.fontWeight = 'normal';
-        interceptOffText.style.fontWeight = 'bold';
-    }
+chrome.storage.sync.get(['owaIntercept', 'owaDomain', 'owaPopup'], (data) => {
+    // Set active radio button
+    radios.find(el => el.value === data.owaIntercept).checked = true;
+    // Set custom domain
+    domainInput.value = data.owaDomain || '';
+    popupCheckbox.checked = data.owaPopup || false;
 });
 
-interceptOn.onclick = () => {
-    chrome.storage.sync.set({owaIntercept: "on"}, () => {
-      console.log('intercept on');
-      interceptOn.checked = true;
-      interceptOnLive.checked = false;
-      interceptOff.checked = false;
-      interceptOnText.style.fontWeight = 'bold';
-      interceptOnLive.style.fontWeight = 'normal';
-      interceptOffText.style.fontWeight = 'normal';
-  });
-}
-
-interceptOnLive.onclick = () => {
-    chrome.storage.sync.set({owaIntercept: "on_live"}, () => {
-      console.log('intercept on_live');
-      interceptOn.checked = false;
-      interceptOnLive.checked = true;
-      interceptOff.checked = false;
-      interceptOnText.style.fontWeight = 'normal';
-      interceptOnLiveText.style.fontWeight = 'bold';
-      interceptOffText.style.fontWeight = 'normal';
-  });
-}
-
-interceptOff.onclick = () => {
-    chrome.storage.sync.set({owaIntercept: "off"}, () => {
-      console.log('intercept off');
-      interceptOn.checked = false;
-      interceptOnLive.checked = false;
-      interceptOff.checked = true;
-      interceptOnText.style.fontWeight = 'normal';
-      interceptOnLiveText.style.fontWeight = 'normal';
-      interceptOffText.style.fontWeight = 'bold';
-  });
-}
+document.addEventListener('change',  e => {
+    // Get active radio button
+    const input = radios.find(el => el.checked);
+    // Store settings
+    chrome.storage.sync.set({
+        owaIntercept: input.value,
+        owaDomain: domainInput.value || null,
+        owaPopup: popupCheckbox.checked,
+    });
+});


### PR DESCRIPTION
I've added the option to define a custom domain for an OWA instance, like many companies (including mine) have. I've also added the option to open the compose window in a popup instead of a new tab and done some refactoring, so that new options are easier to add. I'm using this version unpacked at the moment and it's working well for me.