### PR TITLE
Support links with contents

### DIFF
--- a/mailtowa.js
+++ b/mailtowa.js
@@ -4,8 +4,8 @@
 // https://outlook.{office|live}.com/owa/?path=/mail/action/compose&to={to}&subject={subject}&body={body}&cc={cc}&bcc={bcc}"
 
 const handleLink = (e) => {
-    theTarget = e.target;
-    if (theTarget.tagName.toLowerCase() == 'a' && theTarget.href.substr(0,7) === 'mailto:') {
+    const theTarget = e.composedPath().find(t => t.tagName === 'A' && t.href);
+    if (theTarget && theTarget.href.substr(0,7) === 'mailto:') {
         chrome.storage.sync.get('owaIntercept', (data) => {
             if (String(data.owaIntercept).startsWith("on")) {
                 const mailtoLink = theTarget.href.substr(7).replace('?', '&');


### PR DESCRIPTION
The problem was caused because the click target was actually the path or svg element and not the link. This goes up the tree and finds a link that the clicked element is inside and uses it for the rest of the logic.

Fixes #2